### PR TITLE
Potential fix for code scanning alert no. 9: Missing rate limiting

### DIFF
--- a/app.js
+++ b/app.js
@@ -117,8 +117,16 @@ app.get('/error', (req, res) => {
 // ✅ New Endpoint to Retrieve Logs for a Specific User
 const fs = require('fs');
 const readline = require('readline');
+const RateLimit = require('express-rate-limit');
 
-app.get('/logs/:userId', async (req, res) => {
+// Configure rate limiter: maximum of 10 requests per minute
+const logsRateLimiter = RateLimit({
+  windowMs: 1 * 60 * 1000, // 1 minute
+  max: 10, // max 10 requests per windowMs
+  message: 'Too many requests, please try again later.'
+});
+
+app.get('/logs/:userId', logsRateLimiter, async (req, res) => {
   const userId = req.params.userId;
   const logs = [];
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "@opentelemetry/sdk-node": "^0.200.0",
     "express": "^4.16.4",
     "morgan": "^1.10.0",
-    "winston": "^3.17.0"
+    "winston": "^3.17.0",
+    "express-rate-limit": "^7.5.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.23.0",


### PR DESCRIPTION
Potential fix for [https://github.com/bulma1/shark-website/security/code-scanning/9](https://github.com/bulma1/shark-website/security/code-scanning/9)

To address the issue, we will integrate the `express-rate-limit` middleware into the application. This middleware will limit the number of requests to the `/logs/:userId` endpoint within a specified time window. The fix involves:

1. Installing the `express-rate-limit` package.
2. Configuring a rate limiter with appropriate settings (e.g., maximum requests per minute).
3. Applying the rate limiter specifically to the `/logs/:userId` route.

This approach ensures that the file system access in the route handler is protected against abuse without affecting other parts of the application.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
